### PR TITLE
Add timezone parameter to HuckleberryAPI authentication

### DIFF
--- a/custom_components/huckleberry/config_flow.py
+++ b/custom_components/huckleberry/config_flow.py
@@ -42,7 +42,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 api = HuckleberryAPI(
                     email=user_input[CONF_EMAIL],
                     password=user_input[CONF_PASSWORD],
-                    timezone=dt_util.DEFAULT_TIME_ZONE,
+                    timezone='UTC',
                 )
 
                 await self.hass.async_add_executor_job(api.authenticate)


### PR DESCRIPTION
Ran into an issue when setting up the Huckleberry HA integration and the error in the log was telling me that it was missing the seemingly recently added timezone argument.
Just used HA's default time zone from it's util package in the HuckleberryAPI initializer