### PR TITLE
Add sweetspot sensor support

### DIFF
--- a/custom_components/huckleberry/__init__.py
+++ b/custom_components/huckleberry/__init__.py
@@ -24,6 +24,7 @@ from huckleberry_api import HuckleberryAPI
 from huckleberry_api.firebase_types import (
     BottleType,
     FeedSide,
+    FirebaseChildDocument,
     FirebaseDiaperDocumentData,
     FirebaseFeedDocumentData,
     FirebaseHealthDocumentData,
@@ -498,10 +499,15 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
                 self._realtime_data[uid].diaper_status = data
                 self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, dict(self._realtime_data))
 
+            def child_callback(data: FirebaseChildDocument, uid: str = child_uid) -> None:
+                self._realtime_data[uid].child_document = data
+                self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, dict(self._realtime_data))
+
             await self.api.setup_sleep_listener(child_uid, sleep_callback)
             await self.api.setup_feed_listener(child_uid, feed_callback)
             await self.api.setup_health_listener(child_uid, health_callback)
             await self.api.setup_diaper_listener(child_uid, diaper_callback)
+            await self.api.setup_child_listener(child_uid, child_callback)
 
     async def _async_update_data(self) -> dict[str, HuckleberryChildState]:
         """Refresh auth/session state while listeners provide live data."""
@@ -536,6 +542,11 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
         """Return the current diaper document for a child."""
         state = self.get_state(child_uid)
         return state.diaper_status if state is not None else None
+
+    def get_child_document(self, child_uid: str) -> FirebaseChildDocument | None:
+        """Return the current child document for a child."""
+        state = self.get_state(child_uid)
+        return state.child_document if state is not None else None
 
 async def _async_close_api_firestore_clients(api: HuckleberryAPI) -> None:
     """Close Firestore transports held by the API client.

--- a/custom_components/huckleberry/features/sweetspot.py
+++ b/custom_components/huckleberry/features/sweetspot.py
@@ -1,0 +1,84 @@
+"""Sweetspot-related entities for Huckleberry."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+
+from huckleberry_api.firebase_types import FirebaseChildSweetspot
+
+from .. import HuckleberryDataUpdateCoordinator
+from ..entity import HuckleberryBaseEntity
+from ..models import HuckleberryChildProfile
+from ..timestamps import as_datetime
+
+
+def build_sweetspot_sensors(
+    coordinator: HuckleberryDataUpdateCoordinator,
+    children: list[HuckleberryChildProfile],
+) -> list[SensorEntity]:
+    """Build sweetspot sensors."""
+    return [HuckleberrySweetspotSensor(coordinator, child) for child in children]
+
+
+def _selected_sweetspot_time(sweetspot: FirebaseChildSweetspot | None) -> datetime | None:
+    """Return the sweetspot time for the selected nap-day mode."""
+    if sweetspot is None or not sweetspot.sweetSpotTimes:
+        return None
+
+    selected_nap_day = sweetspot.selectedNapDay
+    if selected_nap_day is None:
+        return None
+
+    selected_key = str(int(float(selected_nap_day)))
+    selected_time = sweetspot.sweetSpotTimes.get(selected_key)
+    if selected_time is None:
+        return None
+
+    return as_datetime(selected_time)
+
+
+class HuckleberrySweetspotSensor(HuckleberryBaseEntity, SensorEntity):
+    """Sensor showing the next predicted sweetspot nap time."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_registry_enabled_default = False
+    _attr_translation_key = "sweetspot"
+
+    def __init__(self, coordinator: HuckleberryDataUpdateCoordinator, child: HuckleberryChildProfile) -> None:
+        super().__init__(coordinator, child)
+        self._attr_unique_id = f"{self.child_uid}_sweetspot"
+
+    @property
+    def _sweetspot(self) -> FirebaseChildSweetspot | None:
+        """Return sweetspot data from the child document."""
+        child_doc = self.coordinator.get_child_document(self.child_uid)
+        if child_doc is not None:
+            return child_doc.sweetspot
+        # Fall back to initial profile document
+        return self._child.document.sweetspot
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the selected sweetspot time as a datetime."""
+        return _selected_sweetspot_time(self._sweetspot)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Return factual sweetspot metadata and predicted times."""
+        sweetspot = self._sweetspot
+        if sweetspot is None:
+            return {}
+
+        attributes: dict[str, object] = {}
+
+        if sweetspot.selectedNapDay is not None:
+            attributes["selected_nap_day"] = sweetspot.selectedNapDay
+
+        if sweetspot.sweetSpotTimes:
+            for key, value in sweetspot.sweetSpotTimes.items():
+                dt = as_datetime(value)
+                if dt is not None:
+                    attributes[f"{key}_nap_day_time"] = dt.isoformat()
+
+        return attributes

--- a/custom_components/huckleberry/manifest.json
+++ b/custom_components/huckleberry/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/Woyken/huckleberry-homeassistant/issues",
   "requirements": ["huckleberry-api==0.4.2"],
-  "version": "0.4.1"
+  "version": "0.4.2"
 }

--- a/custom_components/huckleberry/models.py
+++ b/custom_components/huckleberry/models.py
@@ -78,6 +78,7 @@ class HuckleberryChildState:
     feed_status: FirebaseFeedDocumentData | None = None
     health_status: FirebaseHealthDocumentData | None = None
     diaper_status: FirebaseDiaperDocumentData | None = None
+    child_document: FirebaseChildDocument | None = None
 
     @property
     def growth_data(self) -> FirebaseGrowthData | None:

--- a/custom_components/huckleberry/sensor.py
+++ b/custom_components/huckleberry/sensor.py
@@ -16,6 +16,7 @@ from .features.diaper import build_diaper_sensors
 from .features.growth import build_growth_sensors
 from .features.nursing import build_nursing_sensors
 from .features.sleep import build_sleep_sensors
+from .features.sweetspot import build_sweetspot_sensors
 
 
 async def async_setup_entry(
@@ -32,6 +33,7 @@ async def async_setup_entry(
     entities.extend(build_bottle_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_nursing_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_sleep_sensors(entry_data["coordinator"], entry_data["children"]))
+    entities.extend(build_sweetspot_sensors(entry_data["coordinator"], entry_data["children"]))
 
     async_add_entities(entities)
 

--- a/custom_components/huckleberry/strings.json
+++ b/custom_components/huckleberry/strings.json
@@ -529,6 +529,32 @@
             "name": "Head unit"
           }
         }
+      },
+      "sweetspot": {
+        "name": "Sweetspot",
+        "state_attributes": {
+          "0_nap_day_time": {
+            "name": "0-nap day time"
+          },
+          "1_nap_day_time": {
+            "name": "1-nap day time"
+          },
+          "2_nap_day_time": {
+            "name": "2-nap day time"
+          },
+          "3_nap_day_time": {
+            "name": "3-nap day time"
+          },
+          "4_nap_day_time": {
+            "name": "4-nap day time"
+          },
+          "5_nap_day_time": {
+            "name": "5-nap day time"
+          },
+          "selected_nap_day": {
+            "name": "Selected nap day"
+          }
+        }
       }
     },
     "switch": {

--- a/custom_components/huckleberry/translations/en.json
+++ b/custom_components/huckleberry/translations/en.json
@@ -529,6 +529,32 @@
             "name": "Head unit"
           }
         }
+      },
+      "sweetspot": {
+        "name": "Sweetspot",
+        "state_attributes": {
+          "0_nap_day_time": {
+            "name": "0-nap day time"
+          },
+          "1_nap_day_time": {
+            "name": "1-nap day time"
+          },
+          "2_nap_day_time": {
+            "name": "2-nap day time"
+          },
+          "3_nap_day_time": {
+            "name": "3-nap day time"
+          },
+          "4_nap_day_time": {
+            "name": "4-nap day time"
+          },
+          "5_nap_day_time": {
+            "name": "5-nap day time"
+          },
+          "selected_nap_day": {
+            "name": "Selected nap day"
+          }
+        }
       }
     },
     "switch": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "huckleberry-homeassistant"
-version = "0.4.1"
+version = "0.4.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ def _build_mock_api(
     mock.setup_feed_listener = AsyncMock()
     mock.setup_health_listener = AsyncMock()
     mock.setup_diaper_listener = AsyncMock()
+    mock.setup_child_listener = AsyncMock()
     mock.stop_all_listeners = AsyncMock()
 
     mock.start_sleep = AsyncMock()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,14 +1,16 @@
 """Test Huckleberry sensors."""
-from datetime import datetime, timezone
-from unittest.mock import patch
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
 
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.huckleberry.const import DOMAIN
 from huckleberry_api.firebase_types import (
     FirebaseChildDocument,
+    FirebaseChildSweetspot,
     FirebaseDiaperDocumentData,
     FirebaseDiaperPrefs,
     FirebaseFeedDocumentData,
@@ -172,3 +174,127 @@ async def test_entities_skip_blank_configuration_url(hass: HomeAssistant, mock_h
     assert hass.states.get("switch.test_child_sleep_timer") is not None
     assert hass.states.get("sensor.test_child_profile") is not None
     assert hass.states.get("calendar.test_child_events") is not None
+
+
+async def test_sweetspot_sensor_state_and_attributes(
+    hass: HomeAssistant, mock_huckleberry_api
+):
+    """Test enabled sweetspot sensor follows selected nap-day mode."""
+    mock_huckleberry_api.get_child = AsyncMock(
+        return_value=FirebaseChildDocument(
+            childsName="Test Child",
+            birthdate="2023-01-01",
+            gender="M",
+        )
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test_password",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "child_1_sweetspot",
+        config_entry=entry,
+        disabled_by=None,
+        original_name="Sweetspot",
+        suggested_object_id="test_child_sweetspot",
+    )
+
+    with patch(
+        "custom_components.huckleberry.HuckleberryAPI",
+        return_value=mock_huckleberry_api,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    future_zero = int((datetime.now(tz=timezone.utc) + timedelta(hours=3)).timestamp())
+    future_one = int((datetime.now(tz=timezone.utc) + timedelta(hours=1)).timestamp())
+    future_two = int((datetime.now(tz=timezone.utc) + timedelta(hours=2)).timestamp())
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator._realtime_data["child_1"].child_document = FirebaseChildDocument(
+        childsName="Test Child",
+        birthdate="2023-01-01",
+        gender="M",
+        sweetspot=FirebaseChildSweetspot(
+            selectedNapDay=0,
+            sweetSpotTimes={"0": future_zero, "1": future_two, "2": future_one},
+        ),
+    )
+    coordinator.async_set_updated_data(dict(coordinator._realtime_data))
+    await hass.async_block_till_done()
+
+    sensor_state = hass.states.get("sensor.test_child_sweetspot")
+    assert sensor_state is not None
+    assert sensor_state.state == datetime.fromtimestamp(future_zero, tz=timezone.utc).isoformat()
+    assert sensor_state.attributes["selected_nap_day"] == 0
+    assert sensor_state.attributes["0_nap_day_time"] == datetime.fromtimestamp(future_zero, tz=timezone.utc).isoformat()
+    assert sensor_state.attributes["1_nap_day_time"] == datetime.fromtimestamp(future_two, tz=timezone.utc).isoformat()
+    assert sensor_state.attributes["2_nap_day_time"] == datetime.fromtimestamp(future_one, tz=timezone.utc).isoformat()
+
+
+async def test_sweetspot_sensor_unavailable_when_selected_time_missing(
+    hass: HomeAssistant, mock_huckleberry_api
+):
+    """Test sweetspot sensor is unavailable when selectedNapDay cannot be resolved."""
+    mock_huckleberry_api.get_child = AsyncMock(
+        return_value=FirebaseChildDocument(
+            childsName="Test Child",
+            birthdate="2023-01-01",
+            gender="M",
+        )
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test_password",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    entity_registry = er.async_get(hass)
+    entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "child_1_sweetspot",
+        config_entry=entry,
+        disabled_by=None,
+        original_name="Sweetspot",
+        suggested_object_id="test_child_sweetspot",
+    )
+
+    with patch(
+        "custom_components.huckleberry.HuckleberryAPI",
+        return_value=mock_huckleberry_api,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    future_one = int((datetime.now(tz=timezone.utc) + timedelta(hours=1)).timestamp())
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator._realtime_data["child_1"].child_document = FirebaseChildDocument(
+        childsName="Test Child",
+        birthdate="2023-01-01",
+        gender="M",
+        sweetspot=FirebaseChildSweetspot(
+            selectedNapDay=3,
+            sweetSpotTimes={"1": future_one, "2": future_one},
+        ),
+    )
+    coordinator.async_set_updated_data(dict(coordinator._realtime_data))
+    await hass.async_block_till_done()
+
+    sensor_state = hass.states.get("sensor.test_child_sweetspot")
+    assert sensor_state is not None
+    assert sensor_state.state == "unknown"

--- a/uv.lock
+++ b/uv.lock
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "huckleberry-homeassistant"
-version = "0.4.1"
+version = "0.4.2"
 source = { virtual = "." }
 dependencies = [
     { name = "huckleberry-api" },


### PR DESCRIPTION
## Summary
- add a disabled-by-default sweetspot sensor fed by realtime child document updates
- make the sensor state follow the selected nap-day mode and expose flat `0_nap_day_time` through `5_nap_day_time` attributes
- add test coverage for enabled sweetspot behavior and unresolved selected nap-day handling

#23
