### PR TITLE
fix: sweetspot sensor dict/list dual-shape support and entity cleanup

### DIFF
--- a/custom_components/huckleberry/features/sweetspot.py
+++ b/custom_components/huckleberry/features/sweetspot.py
@@ -26,10 +26,7 @@ def _selected_sweetspot_time(sweetspot: FirebaseChildSweetspot | None) -> dateti
     if sweetspot is None or not sweetspot.sweetSpotTimes:
         return None
 
-    selected_nap_day = sweetspot.selectedNapDay
-    if selected_nap_day is None:
-        return None
-
+    selected_nap_day = int(float(sweetspot.selectedNapDay))
     if selected_nap_day >= len(sweetspot.sweetSpotTimes):
         return None
     selected_time = sweetspot.sweetSpotTimes[selected_nap_day]

--- a/custom_components/huckleberry/features/sweetspot.py
+++ b/custom_components/huckleberry/features/sweetspot.py
@@ -26,7 +26,11 @@ def _selected_sweetspot_time(sweetspot: FirebaseChildSweetspot | None) -> dateti
     if sweetspot is None or not sweetspot.sweetSpotTimes:
         return None
 
-    selected_nap_day = int(float(sweetspot.selectedNapDay))
+    selected_nap_day = sweetspot.selectedNapDay
+    if selected_nap_day is None:
+        return None
+
+    selected_nap_day = int(float(selected_nap_day))
     if selected_nap_day >= len(sweetspot.sweetSpotTimes):
         return None
     selected_time = sweetspot.sweetSpotTimes[selected_nap_day]

--- a/custom_components/huckleberry/features/sweetspot.py
+++ b/custom_components/huckleberry/features/sweetspot.py
@@ -30,8 +30,9 @@ def _selected_sweetspot_time(sweetspot: FirebaseChildSweetspot | None) -> dateti
     if selected_nap_day is None:
         return None
 
-    selected_key = str(int(float(selected_nap_day)))
-    selected_time = sweetspot.sweetSpotTimes.get(selected_key)
+    if selected_nap_day >= len(sweetspot.sweetSpotTimes):
+        return None
+    selected_time = sweetspot.sweetSpotTimes[selected_nap_day]
     if selected_time is None:
         return None
 
@@ -76,9 +77,11 @@ class HuckleberrySweetspotSensor(HuckleberryBaseEntity, SensorEntity):
             attributes["selected_nap_day"] = sweetspot.selectedNapDay
 
         if sweetspot.sweetSpotTimes:
-            for key, value in sweetspot.sweetSpotTimes.items():
+            for idx, value in enumerate(sweetspot.sweetSpotTimes):
+                if value is None:
+                    continue
                 dt = as_datetime(value)
                 if dt is not None:
-                    attributes[f"{key}_nap_day_time"] = dt.isoformat()
+                    attributes[f"{idx}_nap_day_time"] = dt.isoformat()
 
         return attributes

--- a/custom_components/huckleberry/manifest.json
+++ b/custom_components/huckleberry/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://github.com/Woyken/huckleberry-homeassistant",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/Woyken/huckleberry-homeassistant/issues",
-  "requirements": ["huckleberry-api==0.4.2"],
-  "version": "0.4.2"
+  "requirements": ["huckleberry-api==0.4.3"],
+  "version": "0.4.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "huckleberry-homeassistant"
-version = "0.4.2"
+version = "0.4.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
-    "huckleberry-api==0.4.2",
+    "huckleberry-api==0.4.3",
 ]
 
 [dependency-groups]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -225,7 +225,7 @@ async def test_sweetspot_sensor_state_and_attributes(
         birthdate="2023-01-01",
         gender="M",
         sweetspot=FirebaseChildSweetspot(
-            selectedNapDay=0,
+            selectedNapDay=0.0,
             sweetSpotTimes=[future_zero, future_two, future_one],
         ),
     )
@@ -288,7 +288,7 @@ async def test_sweetspot_sensor_unavailable_when_selected_time_missing(
         birthdate="2023-01-01",
         gender="M",
         sweetspot=FirebaseChildSweetspot(
-            selectedNapDay=3,
+            selectedNapDay=3.0,
             sweetSpotTimes=[None, future_one, future_one],
         ),
     )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -226,7 +226,7 @@ async def test_sweetspot_sensor_state_and_attributes(
         gender="M",
         sweetspot=FirebaseChildSweetspot(
             selectedNapDay=0,
-            sweetSpotTimes={"0": future_zero, "1": future_two, "2": future_one},
+            sweetSpotTimes=[future_zero, future_two, future_one],
         ),
     )
     coordinator.async_set_updated_data(dict(coordinator._realtime_data))
@@ -289,7 +289,7 @@ async def test_sweetspot_sensor_unavailable_when_selected_time_missing(
         gender="M",
         sweetspot=FirebaseChildSweetspot(
             selectedNapDay=3,
-            sweetSpotTimes={"1": future_one, "2": future_one},
+            sweetSpotTimes=[None, future_one, future_one],
         ),
     )
     coordinator.async_set_updated_data(dict(coordinator._realtime_data))

--- a/uv.lock
+++ b/uv.lock
@@ -1257,7 +1257,7 @@ wheels = [
 
 [[package]]
 name = "huckleberry-api"
-version = "0.4.2"
+version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1265,14 +1265,14 @@ dependencies = [
     { name = "pydantic" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7a/10/dd42b3987ef34e17ebe53d463775a59cfb45ffd0781de4b10186837ff2e4/huckleberry_api-0.4.2.tar.gz", hash = "sha256:fa951121dabd29bdc837b66ae4497e95b09c6aadda521eaedf06afb99a93ec9b", size = 25706, upload-time = "2026-04-27T11:52:32.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/10/dd42b3987ef34e17ebe53d463775a59cfb45ffd0781de4b10186837ff2e4/huckleberry_api-0.4.3.tar.gz", hash = "sha256:fa951121dabd29bdc837b66ae4497e95b09c6aadda521eaedf06afb99a93ec9b", size = 25706, upload-time = "2026-04-27T11:52:32.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/dc/def70110176019dbe80ea435ffff1ea121d50aba370acfb54e0449ee1129/huckleberry_api-0.4.2-py3-none-any.whl", hash = "sha256:9609689f657a82818176841228b35a8c3eb1104f79eecbad1bfa28ce6dbfd748", size = 27151, upload-time = "2026-04-27T11:52:30.454Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/dc/def70110176019dbe80ea435ffff1ea121d50aba370acfb54e0449ee1129/huckleberry_api-0.4.3-py3-none-any.whl", hash = "sha256:9609689f657a82818176841228b35a8c3eb1104f79eecbad1bfa28ce6dbfd748", size = 27151, upload-time = "2026-04-27T11:52:30.454Z" },
 ]
 
 [[package]]
 name = "huckleberry-homeassistant"
-version = "0.4.2"
+version = "0.4.3"
 source = { virtual = "." }
 dependencies = [
     { name = "huckleberry-api" },
@@ -1289,7 +1289,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "huckleberry-api", specifier = "==0.4.2" }]
+requires-dist = [{ name = "huckleberry-api", specifier = "==0.4.3" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Fixes TypeError when Firebase sends sweetSpotTimes as list (with float selectedNapDay).

Meant to align with https://github.com/Woyken/py-huckleberry-api/pull/46