### PR TITLE
feat: enriched diaper details + daily statistics sensors

### DIFF
--- a/custom_components/huckleberry/__init__.py
+++ b/custom_components/huckleberry/__init__.py
@@ -532,7 +532,7 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
 
     async def _async_refresh_daily_statistics(self, child_uid: str) -> None:
         """Fetch today's intervals from Firebase and compute daily statistics."""
-        from datetime import date, datetime, time as dtime
+        from datetime import datetime, time as dtime
 
         try:
             tz = dt_util.DEFAULT_TIME_ZONE
@@ -540,14 +540,11 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
             start_of_day = datetime.combine(today, dtime.min, tzinfo=tz)
             end_of_day = datetime.combine(today, dtime.max, tzinfo=tz)
 
-            start_ts = int(start_of_day.timestamp())
-            end_ts = int(end_of_day.timestamp())
-
             stats = DailyStatistics(date=today.isoformat())
 
             try:
                 diaper_intervals = await self.api.list_diaper_intervals(
-                    child_uid, start_ts, end_ts
+                    child_uid, start_of_day, end_of_day
                 )
                 stats.diaper_count = len(diaper_intervals)
                 for d in diaper_intervals:
@@ -562,7 +559,7 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
 
             try:
                 feed_intervals = await self.api.list_feed_intervals(
-                    child_uid, start_ts, end_ts
+                    child_uid, start_of_day, end_of_day
                 )
                 from huckleberry_api.firebase_types import (
                     FirebaseBottleFeedIntervalData,
@@ -589,7 +586,7 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
 
             try:
                 sleep_intervals = await self.api.list_sleep_intervals(
-                    child_uid, start_ts, end_ts
+                    child_uid, start_of_day, end_of_day
                 )
                 stats.sleep_count = len(sleep_intervals)
                 for s in sleep_intervals:

--- a/custom_components/huckleberry/__init__.py
+++ b/custom_components/huckleberry/__init__.py
@@ -36,7 +36,7 @@ from huckleberry_api.firebase_types import (
 )
 
 from .const import DOMAIN
-from .models import HuckleberryChildProfile, HuckleberryChildState
+from .models import HuckleberryChildProfile, HuckleberryChildState, DailyStatistics
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -472,6 +472,8 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
         self._realtime_data: dict[str, HuckleberryChildState] = {
             child.uid: HuckleberryChildState(profile=child) for child in children
         }
+        self._last_stats_refresh: float = 0.0
+        self._stats_refresh_interval: float = 300.0  # 5 minutes
         super().__init__(
             hass,
             _LOGGER,
@@ -516,8 +518,91 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
 
     async def _async_update_data(self) -> dict[str, HuckleberryChildState]:
         """Refresh auth/session state while listeners provide live data."""
+        import time
+
         await self.api.ensure_session()
+
+        now = time.monotonic()
+        if now - self._last_stats_refresh >= self._stats_refresh_interval:
+            self._last_stats_refresh = now
+            for child in self.children:
+                await self._async_refresh_daily_statistics(child.uid)
+
         return dict(self._realtime_data)
+
+    async def _async_refresh_daily_statistics(self, child_uid: str) -> None:
+        """Fetch today's intervals from Firebase and compute daily statistics."""
+        from datetime import date, datetime, time as dtime
+
+        try:
+            tz = dt_util.DEFAULT_TIME_ZONE
+            today = dt_util.now().date()
+            start_of_day = datetime.combine(today, dtime.min, tzinfo=tz)
+            end_of_day = datetime.combine(today, dtime.max, tzinfo=tz)
+
+            start_ts = int(start_of_day.timestamp())
+            end_ts = int(end_of_day.timestamp())
+
+            stats = DailyStatistics(date=today.isoformat())
+
+            try:
+                diaper_intervals = await self.api.list_diaper_intervals(
+                    child_uid, start_ts, end_ts
+                )
+                stats.diaper_count = len(diaper_intervals)
+                for d in diaper_intervals:
+                    if d.mode == "pee":
+                        stats.diaper_pee_count += 1
+                    elif d.mode == "poo":
+                        stats.diaper_poo_count += 1
+                    elif d.mode == "both":
+                        stats.diaper_mixed_count += 1
+            except Exception as err:
+                _LOGGER.debug("Failed to fetch diaper intervals for stats: %s", err)
+
+            try:
+                feed_intervals = await self.api.list_feed_intervals(
+                    child_uid, start_ts, end_ts
+                )
+                from huckleberry_api.firebase_types import (
+                    FirebaseBottleFeedIntervalData,
+                    FirebaseBreastFeedIntervalData,
+                    FirebaseSolidsFeedIntervalData,
+                )
+
+                for feed in feed_intervals:
+                    if isinstance(feed, FirebaseBottleFeedIntervalData):
+                        stats.bottle_count += 1
+                        amount = float(feed.amount) if feed.amount is not None else 0.0
+                        if feed.units == "oz":
+                            amount *= 29.5735  # oz to ml
+                        stats.bottle_total_ml += amount
+                    elif isinstance(feed, FirebaseBreastFeedIntervalData):
+                        stats.nursing_count += 1
+                        left = float(feed.leftDuration or 0)
+                        right = float(feed.rightDuration or 0)
+                        stats.nursing_total_seconds += int(left + right)
+                    elif isinstance(feed, FirebaseSolidsFeedIntervalData):
+                        stats.solids_count += 1
+            except Exception as err:
+                _LOGGER.debug("Failed to fetch feed intervals for stats: %s", err)
+
+            try:
+                sleep_intervals = await self.api.list_sleep_intervals(
+                    child_uid, start_ts, end_ts
+                )
+                stats.sleep_count = len(sleep_intervals)
+                for s in sleep_intervals:
+                    stats.sleep_total_seconds += int(float(s.duration))
+            except Exception as err:
+                _LOGGER.debug("Failed to fetch sleep intervals for stats: %s", err)
+
+            self._realtime_data[child_uid].daily_statistics = stats
+
+        except Exception as err:
+            _LOGGER.debug(
+                "Failed to refresh daily statistics for %s: %s", child_uid, err
+            )
 
     async def async_shutdown(self) -> None:
         """Shutdown coordinator and stop active listeners."""
@@ -552,6 +637,11 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
         """Return the latest diaper interval with full details for a child."""
         state = self.get_state(child_uid)
         return state.latest_diaper_interval if state is not None else None
+
+    def get_daily_statistics(self, child_uid: str) -> DailyStatistics | None:
+        """Return the current day's aggregated statistics for a child."""
+        state = self.get_state(child_uid)
+        return state.daily_statistics if state is not None else None
 
     async def _async_fetch_latest_diaper_interval(self, child_uid: str) -> None:
         """Fetch the latest diaper interval and store it in child state."""

--- a/custom_components/huckleberry/__init__.py
+++ b/custom_components/huckleberry/__init__.py
@@ -25,6 +25,7 @@ from huckleberry_api.firebase_types import (
     BottleType,
     FeedSide,
     FirebaseChildDocument,
+    FirebaseDiaperData,
     FirebaseDiaperDocumentData,
     FirebaseFeedDocumentData,
     FirebaseHealthDocumentData,
@@ -497,6 +498,10 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
 
             def diaper_callback(data: FirebaseDiaperDocumentData, uid: str = child_uid) -> None:
                 self._realtime_data[uid].diaper_status = data
+                asyncio.run_coroutine_threadsafe(
+                    self._async_fetch_latest_diaper_interval(uid),
+                    self.hass.loop,
+                )
                 self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, dict(self._realtime_data))
 
             def child_callback(data: FirebaseChildDocument, uid: str = child_uid) -> None:
@@ -542,6 +547,30 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
         """Return the current diaper document for a child."""
         state = self.get_state(child_uid)
         return state.diaper_status if state is not None else None
+
+    def get_latest_diaper_interval(self, child_uid: str) -> FirebaseDiaperData | None:
+        """Return the latest diaper interval with full details for a child."""
+        state = self.get_state(child_uid)
+        return state.latest_diaper_interval if state is not None else None
+
+    async def _async_fetch_latest_diaper_interval(self, child_uid: str) -> None:
+        """Fetch the latest diaper interval and store it in child state."""
+        from datetime import datetime, timedelta
+
+        try:
+            end = datetime.now(dt_util.DEFAULT_TIME_ZONE)
+            start = end - timedelta(days=7)
+            intervals = await self.api.list_diaper_intervals(child_uid, start, end)
+            if intervals:
+                latest = max(intervals, key=lambda i: i.start)
+                self._realtime_data[child_uid].latest_diaper_interval = latest
+                self.async_set_updated_data(dict(self._realtime_data))
+        except Exception as err:
+            _LOGGER.debug(
+                "Failed to fetch latest diaper interval for %s: %s",
+                child_uid,
+                err,
+            )
 
     def get_child_document(self, child_uid: str) -> FirebaseChildDocument | None:
         """Return the current child document for a child."""

--- a/custom_components/huckleberry/calendar.py
+++ b/custom_components/huckleberry/calendar.py
@@ -272,10 +272,26 @@ class HuckleberryCalendar(HuckleberryBaseEntity, CalendarEntity):
             summary = f"{mode_emoji} Diaper ({mode.capitalize()})"
             description = f"Diaper change: {mode}"
 
+            if interval.quantity is not None:
+                amount_map = {0.0: "little", 50.0: "medium", 100.0: "big"}
+                if interval.quantity.pee is not None:
+                    pee_label = amount_map.get(
+                        float(interval.quantity.pee), str(interval.quantity.pee)
+                    )
+                    description += f"\nPee amount: {pee_label}"
+                if interval.quantity.poo is not None:
+                    poo_label = amount_map.get(
+                        float(interval.quantity.poo), str(interval.quantity.poo)
+                    )
+                    description += f"\nPoo amount: {poo_label}"
             if interval.color is not None:
                 description += f"\nColor: {interval.color}"
             if interval.consistency is not None:
                 description += f"\nConsistency: {interval.consistency}"
+            if interval.diaperRash:
+                description += "\nDiaper rash: yes"
+            if interval.notes:
+                description += f"\nNotes: {interval.notes}"
 
             events.append(
                 CalendarEvent(

--- a/custom_components/huckleberry/features/diaper.py
+++ b/custom_components/huckleberry/features/diaper.py
@@ -39,16 +39,39 @@ class HuckleberryDiaperSensor(HuckleberryBaseEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, object]:
-        """Return diaper change attributes."""
+        """Return diaper change attributes including rich interval details."""
         diaper_status = self.coordinator.get_diaper_status(self.child_uid)
         prefs = diaper_status.prefs if diaper_status is not None else None
         last_diaper = prefs.lastDiaper if prefs is not None else None
-        if last_diaper is None:
-            return {}
 
         attributes: dict[str, object] = {}
-        if last_diaper.start is not None:
-            attributes["time"] = as_iso8601_datetime(last_diaper.start)
-        if last_diaper.mode is not None:
-            attributes["type"] = last_diaper.mode.title()
+
+        if last_diaper is not None:
+            if last_diaper.start is not None:
+                attributes["time"] = as_iso8601_datetime(last_diaper.start)
+            if last_diaper.mode is not None:
+                attributes["type"] = last_diaper.mode.title()
+
+        # Enrich with detailed data from the latest interval
+        latest = self.coordinator.get_latest_diaper_interval(self.child_uid)
+        if latest is not None:
+            amount_map = {0.0: "little", 50.0: "medium", 100.0: "big"}
+            if latest.quantity is not None:
+                if latest.quantity.pee is not None:
+                    attributes["pee_amount"] = amount_map.get(
+                        float(latest.quantity.pee), str(latest.quantity.pee)
+                    )
+                if latest.quantity.poo is not None:
+                    attributes["poo_amount"] = amount_map.get(
+                        float(latest.quantity.poo), str(latest.quantity.poo)
+                    )
+            if latest.color is not None:
+                attributes["color"] = latest.color
+            if latest.consistency is not None:
+                attributes["consistency"] = latest.consistency
+            if latest.diaperRash is not None:
+                attributes["diaper_rash"] = latest.diaperRash
+            if latest.notes is not None:
+                attributes["notes"] = latest.notes
+
         return attributes

--- a/custom_components/huckleberry/features/statistics.py
+++ b/custom_components/huckleberry/features/statistics.py
@@ -1,0 +1,172 @@
+"""Daily statistics sensors for Huckleberry."""
+from __future__ import annotations
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+
+from .. import HuckleberryDataUpdateCoordinator
+from ..entity import HuckleberryBaseEntity
+from ..models import DailyStatistics, HuckleberryChildProfile
+
+
+def build_statistics_sensors(
+    coordinator: HuckleberryDataUpdateCoordinator,
+    children: list[HuckleberryChildProfile],
+) -> list[SensorEntity]:
+    """Build daily statistics sensors for each child."""
+    entities: list[SensorEntity] = []
+    for child in children:
+        entities.append(DiapersTodaySensor(coordinator, child))
+        entities.append(BottlesTodaySensor(coordinator, child))
+        entities.append(NursingTodaySensor(coordinator, child))
+        entities.append(SleepTodaySensor(coordinator, child))
+    return entities
+
+
+def _format_duration(total_seconds: int) -> str:
+    """Format seconds as 'Xh Ym' for display."""
+    if total_seconds <= 0:
+        return "0m"
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes = remainder // 60
+    if hours > 0 and minutes > 0:
+        return f"{hours}h {minutes}m"
+    if hours > 0:
+        return f"{hours}h"
+    return f"{minutes}m"
+
+
+class _DailyStatisticsSensorBase(HuckleberryBaseEntity, SensorEntity):
+    """Base class for daily statistics sensors."""
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def _get_stats(self) -> DailyStatistics | None:
+        return self.coordinator.get_daily_statistics(self.child_uid)
+
+
+class DiapersTodaySensor(_DailyStatisticsSensorBase):
+    """Sensor showing today's total diaper changes."""
+
+    _attr_icon = "mdi:baby"
+    _attr_translation_key = "diapers_today"
+    _attr_native_unit_of_measurement = "changes"
+
+    def __init__(
+        self,
+        coordinator: HuckleberryDataUpdateCoordinator,
+        child: HuckleberryChildProfile,
+    ) -> None:
+        super().__init__(coordinator, child)
+        self._attr_unique_id = f"{self.child_uid}_diapers_today"
+
+    @property
+    def native_value(self) -> int | None:
+        stats = self._get_stats()
+        return stats.diaper_count if stats is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        stats = self._get_stats()
+        if stats is None:
+            return {}
+        return {
+            "pee_only": stats.diaper_pee_count,
+            "poo_only": stats.diaper_poo_count,
+            "mixed": stats.diaper_mixed_count,
+            "date": stats.date,
+        }
+
+
+class BottlesTodaySensor(_DailyStatisticsSensorBase):
+    """Sensor showing today's total bottle feedings."""
+
+    _attr_icon = "mdi:baby-bottle"
+    _attr_translation_key = "bottles_today"
+    _attr_native_unit_of_measurement = "bottles"
+
+    def __init__(
+        self,
+        coordinator: HuckleberryDataUpdateCoordinator,
+        child: HuckleberryChildProfile,
+    ) -> None:
+        super().__init__(coordinator, child)
+        self._attr_unique_id = f"{self.child_uid}_bottles_today"
+
+    @property
+    def native_value(self) -> int | None:
+        stats = self._get_stats()
+        return stats.bottle_count if stats is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        stats = self._get_stats()
+        if stats is None:
+            return {}
+        return {
+            "total_ml": round(stats.bottle_total_ml, 1),
+            "date": stats.date,
+        }
+
+
+class NursingTodaySensor(_DailyStatisticsSensorBase):
+    """Sensor showing today's total nursing sessions."""
+
+    _attr_icon = "mdi:mother-nurse"
+    _attr_translation_key = "nursing_today"
+    _attr_native_unit_of_measurement = "sessions"
+
+    def __init__(
+        self,
+        coordinator: HuckleberryDataUpdateCoordinator,
+        child: HuckleberryChildProfile,
+    ) -> None:
+        super().__init__(coordinator, child)
+        self._attr_unique_id = f"{self.child_uid}_nursing_today"
+
+    @property
+    def native_value(self) -> int | None:
+        stats = self._get_stats()
+        return stats.nursing_count if stats is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        stats = self._get_stats()
+        if stats is None:
+            return {}
+        return {
+            "total_duration": _format_duration(stats.nursing_total_seconds),
+            "total_minutes": stats.nursing_total_seconds // 60,
+            "date": stats.date,
+        }
+
+
+class SleepTodaySensor(_DailyStatisticsSensorBase):
+    """Sensor showing today's total sleep."""
+
+    _attr_icon = "mdi:sleep"
+    _attr_translation_key = "sleep_today"
+    _attr_native_unit_of_measurement = "sessions"
+
+    def __init__(
+        self,
+        coordinator: HuckleberryDataUpdateCoordinator,
+        child: HuckleberryChildProfile,
+    ) -> None:
+        super().__init__(coordinator, child)
+        self._attr_unique_id = f"{self.child_uid}_sleep_today"
+
+    @property
+    def native_value(self) -> int | None:
+        stats = self._get_stats()
+        return stats.sleep_count if stats is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        stats = self._get_stats()
+        if stats is None:
+            return {}
+        return {
+            "total_duration": _format_duration(stats.sleep_total_seconds),
+            "total_minutes": stats.sleep_total_seconds // 60,
+            "date": stats.date,
+        }

--- a/custom_components/huckleberry/models.py
+++ b/custom_components/huckleberry/models.py
@@ -18,6 +18,29 @@ from huckleberry_api.firebase_types import (
 from .timestamps import as_iso8601_datetime
 
 
+@dataclass(slots=True)
+class DailyStatistics:
+    """Aggregated daily statistics for a child."""
+
+    date: str  # ISO date string e.g. "2026-05-27"
+
+    diaper_count: int = 0
+    diaper_pee_count: int = 0
+    diaper_poo_count: int = 0
+    diaper_mixed_count: int = 0
+
+    bottle_count: int = 0
+    bottle_total_ml: float = 0.0
+
+    nursing_count: int = 0
+    nursing_total_seconds: int = 0
+
+    sleep_count: int = 0
+    sleep_total_seconds: int = 0
+
+    solids_count: int = 0
+
+
 @dataclass(frozen=True, slots=True)
 class HuckleberryChildProfile:
     """Resolved child profile used by the integration."""
@@ -81,6 +104,7 @@ class HuckleberryChildState:
     diaper_status: FirebaseDiaperDocumentData | None = None
     latest_diaper_interval: FirebaseDiaperData | None = None
     child_document: FirebaseChildDocument | None = None
+    daily_statistics: DailyStatistics | None = None
 
     @property
     def growth_data(self) -> FirebaseGrowthData | None:

--- a/custom_components/huckleberry/models.py
+++ b/custom_components/huckleberry/models.py
@@ -6,6 +6,7 @@ from typing import Sequence
 
 from huckleberry_api.firebase_types import (
     FirebaseChildDocument,
+    FirebaseDiaperData,
     FirebaseDiaperDocumentData,
     FirebaseFeedDocumentData,
     FirebaseGrowthData,
@@ -78,6 +79,7 @@ class HuckleberryChildState:
     feed_status: FirebaseFeedDocumentData | None = None
     health_status: FirebaseHealthDocumentData | None = None
     diaper_status: FirebaseDiaperDocumentData | None = None
+    latest_diaper_interval: FirebaseDiaperData | None = None
     child_document: FirebaseChildDocument | None = None
 
     @property

--- a/custom_components/huckleberry/sensor.py
+++ b/custom_components/huckleberry/sensor.py
@@ -16,6 +16,7 @@ from .features.diaper import build_diaper_sensors
 from .features.growth import build_growth_sensors
 from .features.nursing import build_nursing_sensors
 from .features.sleep import build_sleep_sensors
+from .features.statistics import build_statistics_sensors
 from .features.sweetspot import build_sweetspot_sensors
 
 
@@ -33,6 +34,7 @@ async def async_setup_entry(
     entities.extend(build_bottle_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_nursing_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_sleep_sensors(entry_data["coordinator"], entry_data["children"]))
+    entities.extend(build_statistics_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_sweetspot_sensors(entry_data["coordinator"], entry_data["children"]))
 
     async_add_entities(entities)

--- a/custom_components/huckleberry/strings.json
+++ b/custom_components/huckleberry/strings.json
@@ -555,6 +555,62 @@
             "name": "Selected nap day"
           }
         }
+      },
+      "diapers_today": {
+        "name": "Diapers today",
+        "state_attributes": {
+          "pee_only": {
+            "name": "Pee only"
+          },
+          "poo_only": {
+            "name": "Poo only"
+          },
+          "mixed": {
+            "name": "Mixed"
+          },
+          "date": {
+            "name": "Date"
+          }
+        }
+      },
+      "bottles_today": {
+        "name": "Bottles today",
+        "state_attributes": {
+          "total_ml": {
+            "name": "Total mL"
+          },
+          "date": {
+            "name": "Date"
+          }
+        }
+      },
+      "nursing_today": {
+        "name": "Nursing today",
+        "state_attributes": {
+          "total_duration": {
+            "name": "Total duration"
+          },
+          "total_minutes": {
+            "name": "Total minutes"
+          },
+          "date": {
+            "name": "Date"
+          }
+        }
+      },
+      "sleep_today": {
+        "name": "Sleep today",
+        "state_attributes": {
+          "total_duration": {
+            "name": "Total duration"
+          },
+          "total_minutes": {
+            "name": "Total minutes"
+          },
+          "date": {
+            "name": "Date"
+          }
+        }
       }
     },
     "switch": {

--- a/custom_components/huckleberry/translations/en.json
+++ b/custom_components/huckleberry/translations/en.json
@@ -555,6 +555,62 @@
             "name": "Selected nap day"
           }
         }
+      },
+      "diapers_today": {
+        "name": "Diapers today",
+        "state_attributes": {
+          "pee_only": {
+            "name": "Pee only"
+          },
+          "poo_only": {
+            "name": "Poo only"
+          },
+          "mixed": {
+            "name": "Mixed"
+          },
+          "date": {
+            "name": "Date"
+          }
+        }
+      },
+      "bottles_today": {
+        "name": "Bottles today",
+        "state_attributes": {
+          "total_ml": {
+            "name": "Total mL"
+          },
+          "date": {
+            "name": "Date"
+          }
+        }
+      },
+      "nursing_today": {
+        "name": "Nursing today",
+        "state_attributes": {
+          "total_duration": {
+            "name": "Total duration"
+          },
+          "total_minutes": {
+            "name": "Total minutes"
+          },
+          "date": {
+            "name": "Date"
+          }
+        }
+      },
+      "sleep_today": {
+        "name": "Sleep today",
+        "state_attributes": {
+          "total_duration": {
+            "name": "Total duration"
+          },
+          "total_minutes": {
+            "name": "Total minutes"
+          },
+          "date": {
+            "name": "Date"
+          }
+        }
       }
     },
     "switch": {

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -221,8 +221,9 @@ async def test_statistics_api_called_with_timestamps(
     # Verify the APIs were called (they are called during first refresh)
     mock_huckleberry_api.list_diaper_intervals.assert_called()
     call_args = mock_huckleberry_api.list_diaper_intervals.call_args
-    # Arguments should be (child_uid, start_ts, end_ts)
+    # Arguments should be (child_uid, start_datetime, end_datetime)
     assert call_args[0][0] == "child_1"
-    assert isinstance(call_args[0][1], int)
-    assert isinstance(call_args[0][2], int)
+    from datetime import datetime
+    assert isinstance(call_args[0][1], datetime)
+    assert isinstance(call_args[0][2], datetime)
     assert call_args[0][1] < call_args[0][2]

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1,0 +1,228 @@
+"""Tests for Huckleberry daily statistics sensors."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from huckleberry_api.firebase_types import (
+    FirebaseBottleFeedIntervalData,
+    FirebaseBreastFeedIntervalData,
+    FirebaseDiaperData,
+    FirebaseDiaperQuantity,
+    FirebaseSleepIntervalData,
+    FirebaseSolidsFeedIntervalData,
+)
+
+from custom_components.huckleberry.const import DOMAIN
+
+
+def _make_diaper(mode: str, start: float = 1716800000.0) -> FirebaseDiaperData:
+    """Build a minimal diaper interval."""
+    return FirebaseDiaperData(mode=mode, start=start, offset=36000)
+
+
+def _make_bottle(
+    amount: float = 120.0, units: str = "ml", start: float = 1716800000.0
+) -> FirebaseBottleFeedIntervalData:
+    """Build a minimal bottle interval."""
+    return FirebaseBottleFeedIntervalData(
+        mode="bottle",
+        start=start,
+        bottleType="Formula",
+        amount=amount,
+        units=units,
+        offset=36000,
+    )
+
+
+def _make_nursing(
+    left: float = 300.0, right: float = 240.0, start: float = 1716800000.0
+) -> FirebaseBreastFeedIntervalData:
+    """Build a minimal breast feed interval."""
+    return FirebaseBreastFeedIntervalData(
+        mode="breast",
+        start=start,
+        lastSide="left",
+        leftDuration=left,
+        rightDuration=right,
+        offset=36000,
+    )
+
+
+def _make_sleep(
+    duration: float = 3600.0, start: float = 1716800000.0
+) -> FirebaseSleepIntervalData:
+    """Build a minimal sleep interval."""
+    return FirebaseSleepIntervalData(
+        start=start,
+        duration=duration,
+        offset=36000,
+    )
+
+
+def _make_solids(start: float = 1716800000.0) -> FirebaseSolidsFeedIntervalData:
+    """Build a minimal solids interval."""
+    return FirebaseSolidsFeedIntervalData(
+        mode="solids",
+        start=start,
+        offset=36000,
+    )
+
+
+async def _setup_integration(
+    hass: HomeAssistant,
+    mock_api,
+    *,
+    diapers: list | None = None,
+    feeds: list | None = None,
+    sleeps: list | None = None,
+):
+    """Set up the integration with optional interval data."""
+    mock_api.list_diaper_intervals = AsyncMock(return_value=diapers or [])
+    mock_api.list_feed_intervals = AsyncMock(return_value=feeds or [])
+    mock_api.list_sleep_intervals = AsyncMock(return_value=sleeps or [])
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test_password",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.huckleberry.HuckleberryAPI",
+        return_value=mock_api,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry
+
+
+async def test_statistics_sensors_no_data(hass: HomeAssistant, mock_huckleberry_api):
+    """Test statistics sensors show 0 when no intervals exist."""
+    await _setup_integration(hass, mock_huckleberry_api)
+
+    diapers = hass.states.get("sensor.test_child_diapers_today")
+    assert diapers is not None
+    assert diapers.state == "0"
+
+    bottles = hass.states.get("sensor.test_child_bottles_today")
+    assert bottles is not None
+    assert bottles.state == "0"
+
+    nursing = hass.states.get("sensor.test_child_nursing_today")
+    assert nursing is not None
+    assert nursing.state == "0"
+
+    sleep = hass.states.get("sensor.test_child_sleep_today")
+    assert sleep is not None
+    assert sleep.state == "0"
+
+
+async def test_diaper_counts(hass: HomeAssistant, mock_huckleberry_api):
+    """Test diaper sensor counts by type."""
+    diapers = [
+        _make_diaper("pee", 1716800100.0),
+        _make_diaper("poo", 1716800200.0),
+        _make_diaper("both", 1716800300.0),
+        _make_diaper("pee", 1716800400.0),
+        _make_diaper("dry", 1716800500.0),
+    ]
+    await _setup_integration(hass, mock_huckleberry_api, diapers=diapers)
+
+    state = hass.states.get("sensor.test_child_diapers_today")
+    assert state is not None
+    assert state.state == "5"
+    assert state.attributes["pee_only"] == 2
+    assert state.attributes["poo_only"] == 1
+    assert state.attributes["mixed"] == 1
+
+
+async def test_bottle_totals(hass: HomeAssistant, mock_huckleberry_api):
+    """Test bottle sensor counts and total ml."""
+    feeds = [
+        _make_bottle(120.0, "ml", 1716800100.0),
+        _make_bottle(90.0, "ml", 1716800200.0),
+        _make_bottle(4.0, "oz", 1716800300.0),  # ~118.3 ml
+    ]
+    await _setup_integration(hass, mock_huckleberry_api, feeds=feeds)
+
+    state = hass.states.get("sensor.test_child_bottles_today")
+    assert state is not None
+    assert state.state == "3"
+    total_ml = state.attributes["total_ml"]
+    assert 328.0 < total_ml < 329.0  # 120 + 90 + 118.3
+
+
+async def test_nursing_totals(hass: HomeAssistant, mock_huckleberry_api):
+    """Test nursing sensor counts and total duration."""
+    feeds = [
+        _make_nursing(300.0, 240.0, 1716800100.0),  # 9 min
+        _make_nursing(420.0, 0.0, 1716800200.0),  # 7 min
+    ]
+    await _setup_integration(hass, mock_huckleberry_api, feeds=feeds)
+
+    state = hass.states.get("sensor.test_child_nursing_today")
+    assert state is not None
+    assert state.state == "2"
+    assert state.attributes["total_minutes"] == 16  # (540 + 420) // 60
+    assert state.attributes["total_duration"] == "16m"
+
+
+async def test_sleep_totals(hass: HomeAssistant, mock_huckleberry_api):
+    """Test sleep sensor counts and total duration."""
+    sleeps = [
+        _make_sleep(3600.0, 1716800100.0),  # 1h
+        _make_sleep(2700.0, 1716800200.0),  # 45m
+        _make_sleep(5400.0, 1716800300.0),  # 1h 30m
+    ]
+    await _setup_integration(hass, mock_huckleberry_api, sleeps=sleeps)
+
+    state = hass.states.get("sensor.test_child_sleep_today")
+    assert state is not None
+    assert state.state == "3"
+    assert state.attributes["total_minutes"] == 195  # (3600+2700+5400) // 60
+    assert state.attributes["total_duration"] == "3h 15m"
+
+
+async def test_mixed_feed_types(hass: HomeAssistant, mock_huckleberry_api):
+    """Test that bottles, nursing, and solids all count correctly together."""
+    feeds = [
+        _make_bottle(120.0, "ml", 1716800100.0),
+        _make_nursing(300.0, 300.0, 1716800200.0),
+        _make_solids(1716800300.0),
+        _make_bottle(90.0, "ml", 1716800400.0),
+    ]
+    await _setup_integration(hass, mock_huckleberry_api, feeds=feeds)
+
+    bottles = hass.states.get("sensor.test_child_bottles_today")
+    assert bottles is not None
+    assert bottles.state == "2"
+    assert bottles.attributes["total_ml"] == 210.0
+
+    nursing = hass.states.get("sensor.test_child_nursing_today")
+    assert nursing is not None
+    assert nursing.state == "1"
+
+
+async def test_statistics_api_called_with_timestamps(
+    hass: HomeAssistant, mock_huckleberry_api
+):
+    """Test that the coordinator passes integer timestamps to list APIs."""
+    await _setup_integration(hass, mock_huckleberry_api)
+
+    # Verify the APIs were called (they are called during first refresh)
+    mock_huckleberry_api.list_diaper_intervals.assert_called()
+    call_args = mock_huckleberry_api.list_diaper_intervals.call_args
+    # Arguments should be (child_uid, start_ts, end_ts)
+    assert call_args[0][0] == "child_1"
+    assert isinstance(call_args[0][1], int)
+    assert isinstance(call_args[0][2], int)
+    assert call_args[0][1] < call_args[0][2]


### PR DESCRIPTION
## Summary

This PR adds two features that make the integration significantly more useful for day-to-day parenting:

1. **Enriched diaper details** — Calendar events and diaper sensor now surface quantity (pee/poo amounts), color, consistency, diaper rash, and notes from Firebase interval data.
2. **Daily statistics sensors** — Four new per-child sensors that aggregate today's activity from Firebase, refreshed every 5 minutes. No external scripts, YAML config, or HACS dependencies needed — they're native integration sensors.

## New Sensors

Each child gets four daily statistics sensors:

| Entity | State | Attributes | Unit |
|--------|-------|------------|------|
| `sensor.{child}_diapers_today` | Total changes today | `pee_only`, `poo_only`, `mixed`, `date` | changes |
| `sensor.{child}_bottles_today` | Total bottles today | `total_ml`, `date` | bottles |
| `sensor.{child}_nursing_today` | Total sessions today | `total_duration`, `total_minutes`, `date` | sessions |
| `sensor.{child}_sleep_today` | Total sessions today | `total_duration`, `total_minutes`, `date` | sessions |

All have `state_class: measurement`, making them compatible with tile cards, history graphs, and HA statistics out of the box. Values reset at midnight (the coordinator re-queries the current day's date range).

### Diaper Sensor Enrichment

`sensor.{child}_diaper` now includes these extra attributes when data is available:

- `pee_amount` — "little" / "medium" / "big"
- `poo_amount` — "little" / "medium" / "big"  
- `color` — yellow, brown, black, green, red, gray
- `consistency` — solid, loose, runny, mucousy, hard, pebbles, diarrhea
- `diaper_rash` — boolean
- `notes` — free-text

These are fetched from the latest diaper interval via `list_diaper_intervals()` and the Firebase quantity mapping (0.0→little, 50.0→medium, 100.0→big).

### Calendar Event Enrichment

Diaper calendar events now include quantity, rash, and notes in the description field, in addition to the existing color and consistency fields.

## Architecture

### Data Flow

The coordinator already runs a 60-second poll for auth/session refresh. Daily statistics piggyback on this with a **5-minute debounce** (`time.monotonic` based):

```
Coordinator._async_update_data() (every 60s)
  └─ if 5 min since last stats refresh:
       └─ _async_refresh_daily_statistics(child_uid)
            ├─ api.list_diaper_intervals(child_uid, start_of_day, end_of_day)
            ├─ api.list_feed_intervals(child_uid, start_of_day, end_of_day)
            └─ api.list_sleep_intervals(child_uid, start_of_day, end_of_day)
```

Each interval type is fetched independently with try/except — a failure in one category doesn't block the others.

### Model

`DailyStatistics` dataclass in `models.py` holds per-category counts and totals. Stored on `HuckleberryChildState.daily_statistics`.

### Sensors

`features/statistics.py` contains four `SensorEntity` subclasses, all extending a shared `_DailyStatisticsSensorBase` that reads from the coordinator. Pattern follows the existing feature module convention.

## Files Changed

| File | Change |
|------|--------|
| `__init__.py` | Coordinator: stats refresh method, debounce timer, `get_daily_statistics()` accessor |
| `calendar.py` | Diaper event descriptions: quantity, rash, notes fields |
| `features/diaper.py` | Sensor attributes: pee_amount, poo_amount, color, consistency, rash, notes |
| `features/statistics.py` | **New** — Four daily statistics sensor classes |
| `models.py` | `DailyStatistics` dataclass, new field on `HuckleberryChildState` |
| `sensor.py` | Register `build_statistics_sensors` |
| `strings.json` | Translation keys for 4 new sensors + attributes |
| `translations/en.json` | English translations for 4 new sensors + attributes |
| `tests/test_statistics.py` | **New** — 7 tests covering all sensor types, mixed feeds, API call validation |

## Testing

- 7 new tests in `test_statistics.py`
- Full suite: **39 passed, 1 skipped** (the skipped test is `test_live_integration` which requires credentials)
- Tested live on HA 2026.5.4 with real Huckleberry account data

## Breaking Changes

None. All new functionality is additive. Existing sensors and services are unchanged.

## Screenshots

The new sensors work with standard HA dashboard cards (tile, entities, markdown, etc.):

- **Tile cards** show the count with unit (e.g. "3 changes", "5 sessions")
- **Tap** reveals attributes (breakdown by type, total ml, total duration)
- **Markdown cards** can render rich summaries using Jinja2 templates referencing the sensor attributes

## Checklist

- [x] Follows existing code patterns (feature modules, coordinator, base entity)
- [x] Multi-child support (sensors created per child)
- [x] Translation keys in both `strings.json` and `translations/en.json`
- [x] Tests for all new functionality
- [x] No new dependencies
- [x] No breaking changes
- [x] Graceful error handling (individual API failures don't block other categories)
