### PR TITLE
Add pumping sensors

### DIFF
--- a/custom_components/huckleberry/__init__.py
+++ b/custom_components/huckleberry/__init__.py
@@ -28,6 +28,7 @@ from huckleberry_api.firebase_types import (
     FirebaseDiaperDocumentData,
     FirebaseFeedDocumentData,
     FirebaseHealthDocumentData,
+    FirebasePumpDocumentData,
     FirebaseSleepDocumentData,
     FirebaseUserDocument,
     PooColor,
@@ -499,6 +500,10 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
                 self._realtime_data[uid].diaper_status = data
                 self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, dict(self._realtime_data))
 
+            def pump_callback(data: FirebasePumpDocumentData, uid: str = child_uid) -> None:
+                self._realtime_data[uid].pump_status = data
+                self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, dict(self._realtime_data))
+
             def child_callback(data: FirebaseChildDocument, uid: str = child_uid) -> None:
                 self._realtime_data[uid].child_document = data
                 self.hass.loop.call_soon_threadsafe(self.async_set_updated_data, dict(self._realtime_data))
@@ -507,6 +512,7 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
             await self.api.setup_feed_listener(child_uid, feed_callback)
             await self.api.setup_health_listener(child_uid, health_callback)
             await self.api.setup_diaper_listener(child_uid, diaper_callback)
+            await self.api.setup_pump_listener(child_uid, pump_callback)
             await self.api.setup_child_listener(child_uid, child_callback)
 
     async def _async_update_data(self) -> dict[str, HuckleberryChildState]:
@@ -532,6 +538,11 @@ class HuckleberryDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Huckleber
         """Return the current feed document for a child."""
         state = self.get_state(child_uid)
         return state.feed_status if state is not None else None
+
+    def get_pump_status(self, child_uid: str) -> FirebasePumpDocumentData | None:
+        """Return the current pump document for a child."""
+        state = self.get_state(child_uid)
+        return state.pump_status if state is not None else None
 
     def get_health_status(self, child_uid: str) -> FirebaseHealthDocumentData | None:
         """Return the current health document for a child."""

--- a/custom_components/huckleberry/features/pumping.py
+++ b/custom_components/huckleberry/features/pumping.py
@@ -1,0 +1,117 @@
+"""Pumping-related entities for Huckleberry."""
+from __future__ import annotations
+
+from typing import Final
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+
+from .. import HuckleberryDataUpdateCoordinator
+from ..entity import HuckleberryBaseEntity
+from ..models import HuckleberryChildProfile
+from ..timestamps import as_datetime, as_iso8601_datetime, as_iso8601_duration
+
+PUMP_STATE_OPTIONS: Final[list[str]] = ["active", "paused", "none"]
+
+
+def build_pumping_sensors(
+    coordinator: HuckleberryDataUpdateCoordinator,
+    children: list[HuckleberryChildProfile],
+) -> list[SensorEntity]:
+    """Build pumping-related sensors."""
+    entities: list[SensorEntity] = []
+    for child in children:
+        entities.append(HuckleberryPumpingSensor(coordinator, child))
+        entities.append(HuckleberryLastPumpSensor(coordinator, child))
+    return entities
+
+
+class HuckleberryPumpingSensor(HuckleberryBaseEntity, SensorEntity):
+    """Representation of a Huckleberry pumping session sensor."""
+
+    _attr_icon = "mdi:mother-nurse"
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = PUMP_STATE_OPTIONS
+    _attr_translation_key = "pumping"
+
+    def __init__(self, coordinator: HuckleberryDataUpdateCoordinator, child: HuckleberryChildProfile) -> None:
+        super().__init__(coordinator, child)
+        self._attr_unique_id = f"{self.child_uid}_pumping"
+
+    @property
+    def native_value(self):
+        """Return the state of the sensor."""
+        pump_status = self.coordinator.get_pump_status(self.child_uid)
+        timer = pump_status.timer if pump_status is not None else None
+        if timer is None:
+            return None
+        if not timer.active:
+            return "none"
+        return "paused" if timer.paused else "active"
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Return entity specific state attributes."""
+        pump_status = self.coordinator.get_pump_status(self.child_uid)
+        if pump_status is None:
+            return {}
+
+        timer = pump_status.timer
+        attributes: dict[str, object] = {}
+
+        if timer is not None and timer.active:
+            if timer.startTime is not None:
+                attributes["current_start"] = as_iso8601_datetime(timer.startTime)
+            if timer.entryMode is not None:
+                attributes["current_entry_mode"] = timer.entryMode
+            if timer.units is not None:
+                attributes["current_units"] = timer.units
+
+        return attributes
+
+
+class HuckleberryLastPumpSensor(HuckleberryBaseEntity, SensorEntity):
+    """Sensor showing last completed pump session information."""
+
+    _attr_icon = "mdi:baby-bottle-outline"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_translation_key = "last_pump"
+
+    def __init__(self, coordinator: HuckleberryDataUpdateCoordinator, child: HuckleberryChildProfile) -> None:
+        super().__init__(coordinator, child)
+        self._attr_unique_id = f"{self.child_uid}_last_pump"
+
+    def _last_pump(self):
+        pump_status = self.coordinator.get_pump_status(self.child_uid)
+        prefs = pump_status.prefs if pump_status is not None else None
+        return prefs.lastPump if prefs is not None else None
+
+    @property
+    def native_value(self):
+        """Return the last pump session timestamp."""
+        last_pump = self._last_pump()
+        return as_datetime(last_pump.start if last_pump is not None else None)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Return last pump session attributes."""
+        last_pump = self._last_pump()
+        if last_pump is None:
+            return {}
+
+        attributes: dict[str, object] = {}
+        if last_pump.start is not None:
+            attributes["time"] = as_iso8601_datetime(last_pump.start)
+        if last_pump.duration is not None:
+            attributes["duration"] = as_iso8601_duration(last_pump.duration)
+        if last_pump.entryMode is not None:
+            attributes["entry_mode"] = last_pump.entryMode
+        if last_pump.leftAmount is not None:
+            attributes["left_amount"] = last_pump.leftAmount
+        if last_pump.rightAmount is not None:
+            attributes["right_amount"] = last_pump.rightAmount
+        if last_pump.leftAmount is not None and last_pump.rightAmount is not None:
+            attributes["total_amount"] = last_pump.leftAmount + last_pump.rightAmount
+        if last_pump.units is not None:
+            attributes["units"] = last_pump.units
+
+        return attributes

--- a/custom_components/huckleberry/models.py
+++ b/custom_components/huckleberry/models.py
@@ -10,6 +10,7 @@ from huckleberry_api.firebase_types import (
     FirebaseFeedDocumentData,
     FirebaseGrowthData,
     FirebaseHealthDocumentData,
+    FirebasePumpDocumentData,
     FirebaseSleepDocumentData,
     FirebaseUserChildRef,
 )
@@ -78,6 +79,7 @@ class HuckleberryChildState:
     feed_status: FirebaseFeedDocumentData | None = None
     health_status: FirebaseHealthDocumentData | None = None
     diaper_status: FirebaseDiaperDocumentData | None = None
+    pump_status: FirebasePumpDocumentData | None = None
     child_document: FirebaseChildDocument | None = None
 
     @property

--- a/custom_components/huckleberry/sensor.py
+++ b/custom_components/huckleberry/sensor.py
@@ -15,6 +15,7 @@ from .features.child import build_child_sensors
 from .features.diaper import build_diaper_sensors
 from .features.growth import build_growth_sensors
 from .features.nursing import build_nursing_sensors
+from .features.pumping import build_pumping_sensors
 from .features.sleep import build_sleep_sensors
 from .features.sweetspot import build_sweetspot_sensors
 
@@ -32,6 +33,7 @@ async def async_setup_entry(
     entities.extend(build_diaper_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_bottle_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_nursing_sensors(entry_data["coordinator"], entry_data["children"]))
+    entities.extend(build_pumping_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_sleep_sensors(entry_data["coordinator"], entry_data["children"]))
     entities.extend(build_sweetspot_sensors(entry_data["coordinator"], entry_data["children"]))
 

--- a/custom_components/huckleberry/strings.json
+++ b/custom_components/huckleberry/strings.json
@@ -555,6 +555,51 @@
             "name": "Selected nap day"
           }
         }
+      },
+      "pumping": {
+        "name": "Pumping",
+        "state": {
+          "active": "Active",
+          "paused": "Paused",
+          "none": "None"
+        },
+        "state_attributes": {
+          "current_start": {
+            "name": "Current start"
+          },
+          "current_entry_mode": {
+            "name": "Current entry mode"
+          },
+          "current_units": {
+            "name": "Current units"
+          }
+        }
+      },
+      "last_pump": {
+        "name": "Last pump",
+        "state_attributes": {
+          "time": {
+            "name": "Time"
+          },
+          "duration": {
+            "name": "Duration"
+          },
+          "entry_mode": {
+            "name": "Entry mode"
+          },
+          "left_amount": {
+            "name": "Left amount"
+          },
+          "right_amount": {
+            "name": "Right amount"
+          },
+          "total_amount": {
+            "name": "Total amount"
+          },
+          "units": {
+            "name": "Units"
+          }
+        }
       }
     },
     "switch": {

--- a/custom_components/huckleberry/translations/en.json
+++ b/custom_components/huckleberry/translations/en.json
@@ -555,6 +555,51 @@
             "name": "Selected nap day"
           }
         }
+      },
+      "pumping": {
+        "name": "Pumping",
+        "state": {
+          "active": "Active",
+          "paused": "Paused",
+          "none": "None"
+        },
+        "state_attributes": {
+          "current_start": {
+            "name": "Current start"
+          },
+          "current_entry_mode": {
+            "name": "Current entry mode"
+          },
+          "current_units": {
+            "name": "Current units"
+          }
+        }
+      },
+      "last_pump": {
+        "name": "Last pump",
+        "state_attributes": {
+          "time": {
+            "name": "Time"
+          },
+          "duration": {
+            "name": "Duration"
+          },
+          "entry_mode": {
+            "name": "Entry mode"
+          },
+          "left_amount": {
+            "name": "Left amount"
+          },
+          "right_amount": {
+            "name": "Right amount"
+          },
+          "total_amount": {
+            "name": "Total amount"
+          },
+          "units": {
+            "name": "Units"
+          }
+        }
       }
     },
     "switch": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ def _build_mock_api(
     mock.setup_feed_listener = AsyncMock()
     mock.setup_health_listener = AsyncMock()
     mock.setup_diaper_listener = AsyncMock()
+    mock.setup_pump_listener = AsyncMock()
     mock.setup_child_listener = AsyncMock()
     mock.stop_all_listeners = AsyncMock()
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -20,6 +20,9 @@ from huckleberry_api.firebase_types import (
     FirebaseHealthPrefs,
     FirebaseLastBottleData,
     FirebaseLastDiaperData,
+    FirebaseLastPumpData,
+    FirebasePumpDocumentData,
+    FirebasePumpPrefs,
 )
 
 
@@ -350,3 +353,59 @@ async def test_sweetspot_sensor_handles_sparse_null_slots(
     assert sensor_state.attributes["selected_nap_day"] == 0
     assert sensor_state.attributes["0_nap_day_time"] == datetime.fromtimestamp(future_zero, tz=timezone.utc).isoformat()
     assert "1_nap_day_time" not in sensor_state.attributes
+
+async def test_pumping_sensors(hass: HomeAssistant, mock_huckleberry_api):
+    """Test pumping sensors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "test@example.com",
+            CONF_PASSWORD: "test_password",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.huckleberry.HuckleberryAPI",
+        return_value=mock_huckleberry_api,
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+
+    # Simulate a completed pump session via typed models
+    state = coordinator._realtime_data["child_1"]
+    state.pump_status = FirebasePumpDocumentData(
+        prefs=FirebasePumpPrefs(
+            lastPump=FirebaseLastPumpData(
+                start=1234567890,
+                duration=600,
+                entryMode="leftright",
+                leftAmount=10.0,
+                rightAmount=15.0,
+                units="ml",
+                offset=0,
+            ),
+        ),
+    )
+    coordinator.async_set_updated_data(dict(coordinator._realtime_data))
+    await hass.async_block_till_done()
+
+    # Last pump sensor exposes the completed session
+    sensor_state = hass.states.get("sensor.test_child_last_pump")
+    assert sensor_state is not None
+    expected_date = datetime.fromtimestamp(1234567890, tz=timezone.utc).isoformat()
+    assert sensor_state.state == expected_date
+    assert sensor_state.attributes["entry_mode"] == "leftright"
+    assert sensor_state.attributes["left_amount"] == 10.0
+    assert sensor_state.attributes["right_amount"] == 15.0
+    assert sensor_state.attributes["total_amount"] == 25.0
+    assert sensor_state.attributes["units"] == "ml"
+    assert sensor_state.attributes["duration"] == "PT10M"
+
+    # Pumping state sensor has no timer data -> unknown
+    sensor_state = hass.states.get("sensor.test_child_pumping")
+    assert sensor_state is not None
+    assert sensor_state.state == "unknown"
+


### PR DESCRIPTION
The API library already supports the pump document but the integration never exposed it. This adds two sensors per child, following the same pattern as the existing bottle/nursing sensors:

- `last_pump` — timestamp of the last completed session, with duration, entry mode, left/right/total amounts and units from `prefs.lastPump`
- `pumping` — active/paused/none from the pump timer

Realtime pump listener wired into the coordinator, plus translations and a test.

Tested against my own account — sessions logged in the app show up in HA within a couple of seconds.