### PR TITLE
Release v0.5.0

### DIFF
--- a/custom_components/huckleberry/manifest.json
+++ b/custom_components/huckleberry/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/Woyken/huckleberry-homeassistant/issues",
   "requirements": ["huckleberry-api==0.4.3"],
-  "version": "0.4.3"
+  "version": "0.5.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "huckleberry-homeassistant"
-version = "0.4.3"
+version = "0.5.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1272,7 +1272,7 @@ wheels = [
 
 [[package]]
 name = "huckleberry-homeassistant"
-version = "0.4.3"
+version = "0.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "huckleberry-api" },


### PR DESCRIPTION
## Summary

Bump the integration version to 0.5.0 for the potty tracking release.

## Verification

- `uv lock --check`
- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest` (32 passed, 1 live test skipped)